### PR TITLE
[GDP-690] Implement products entity

### DIFF
--- a/tap_hubspot/schemas/products.json
+++ b/tap_hubspot/schemas/products.json
@@ -1,0 +1,43 @@
+{
+    "type": "object",
+    "properties": {
+        "name": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "description": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "price": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "createdate": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "hs_lastmodifieddate": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        },
+        "hs_object_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        }
+    }
+}


### PR DESCRIPTION
- Criação da função `sync_products` usada pela stream _products_;
- Adicionando os endpoints para obter os dados e as properties de _products_;
- Alteração na função `get_v3_schema` para obter as properties de products usando o endpoint da versão 3 (products_v3_properties);
- Alteração na função `load_schema`, adicionando a entidade products a lista de entidades que terão um schema customizado;
- Criação das funções `process_v3_products_records` e `get_v3_products`;
- Alteração na função `gen_request` para considerar quando o tap_stream_id for products. Nesses casos  os dados obtidos a partir do endpoint da v3 da api, será mergeado com os dados obtidos pelo endpoint da v1;
- Criação do arquivo products.json com o schema da entidade.