### PR TITLE
[GDP-691] Implement line_items entity

### DIFF
--- a/tap_hubspot/schemas/line_items.json
+++ b/tap_hubspot/schemas/line_items.json
@@ -1,0 +1,42 @@
+{
+    "type": "object",
+    "properties": {
+        "objectType": {
+            "type": [
+                "null",
+                "string"
+            ]
+        },
+        "portalId": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "objectId": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "isDeleted": {
+            "type": [
+                "null",
+                "boolean"
+            ]
+        },
+        "hs_product_id": {
+            "type": [
+                "null",
+                "integer"
+            ]
+        },
+        "hs_lastmodifieddate": {
+            "type": [
+                "null",
+                "string"
+            ],
+            "format": "date-time"
+        }
+    }
+}


### PR DESCRIPTION
- Adding the line_items entity
- Adding the line_items schema file

In the `gen_request` function, if the entity is _line_items_, we will use the `merge_responses_products` function because the parameters used to join the version 1 and 3 data are the same as for the _products_ entity: `id and objectId`

