### PR TITLE
fix(tap-hubspot): change key property from id to objectId

### DIFF
--- a/tap_hubspot/__init__.py
+++ b/tap_hubspot/__init__.py
@@ -1121,7 +1121,7 @@ def sync_products(STATE, ctx):
               'properties': ['name', 'description', 'price', 'hs_lastmodifieddate']}
     
     schema = load_schema("products")
-    singer.write_schema("products", schema, ["id"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("products", schema, ["objectId"], [bookmark_key], catalog.get('stream_alias'))
 
     # Check if we should  include associations
     for key in mdata.keys():
@@ -1218,7 +1218,7 @@ def sync_line_items(STATE, ctx):
               'properties': ['name', 'description', 'price', 'hs_lastmodifieddate', 'hs_product_id']}
     
     schema = load_schema("line_items")
-    singer.write_schema("line_items", schema, ["id"], [bookmark_key], catalog.get('stream_alias'))
+    singer.write_schema("line_items", schema, ["objectId"], [bookmark_key], catalog.get('stream_alias'))
 
     # Check if we should  include associations
     for key in mdata.keys():
@@ -1324,8 +1324,8 @@ STREAMS = [
     Stream('lead', sync_lead, ["id"], 'updatedAt', 'INCREMENTAL'),
     # Do these last as they are full table
     Stream('associations_line_items_deals_v3', sync_associations_line_items_deals_v3, ['id'], 'updatedAt', 'FULL_TABLE'),
-    Stream('line_items', sync_line_items, ['id'], 'hs_lastmodifieddate', 'FULL_TABLE'),
-    Stream('products', sync_products, ['id'], 'hs_lastmodifieddate', 'FULL_TABLE'),
+    Stream('line_items', sync_line_items, ['objectId'], 'hs_lastmodifieddate', 'FULL_TABLE'),
+    Stream('products', sync_products, ['objectId'], 'hs_lastmodifieddate', 'FULL_TABLE'),
     Stream('forms', sync_forms, ['guid'], 'updatedAt', 'FULL_TABLE'),
     Stream('workflows', sync_workflows, ['id'], 'updatedAt', 'FULL_TABLE'),
     Stream('owners', sync_owners, ['id'], 'updatedAt', 'FULL_TABLE'),


### PR DESCRIPTION
- Alteração da `key_propertie` na definição do esquema de `id` para `objectId` para alinhar com a estrutura de resposta da API HubSpot e o esquema das entidades products e line_items.

O erro `MissingKeyPropertiesError` está ocorrendo, pois no tap-hubspot temos o campo id sendo passado como uma `key_propertie` nas entidades **products** e **line_items**, porém os endpoints usados para obter os dados são da versão v1 da API hubspot onde temos o objectId como pk, quando o singer vai validar a mensagem do schema o campo **id** não é encontrado.