### PR TITLE
PDD-2017(fix): json schema

### DIFF
--- a/tap_hubspot/schemas/associations_line_items_deals_v3.json
+++ b/tap_hubspot/schemas/associations_line_items_deals_v3.json
@@ -48,19 +48,17 @@
           "properties": {
             "results": {
               "type": "array",
-              "items": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "type": "string"
-                    }
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
                   }
                 }
-              ]
+              }
             }
           }
         }

--- a/tap_hubspot/schemas/lead.json
+++ b/tap_hubspot/schemas/lead.json
@@ -711,19 +711,17 @@
           "properties": {
             "results": {
               "type": "array",
-              "items": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "id": {
-                      "type": "string"
-                    },
-                    "type": {
-                      "type": "string"
-                    }
+              "items": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "type": {
+                    "type": "string"
                   }
                 }
-              ]
+              }
             }
           }
         }


### PR DESCRIPTION
The tap-hubspot schema files were incompatible with the JSON Schema drafts. Starting with Meltano SDK v0.43.0+, JSON Schema validation switched to draft 2020-12. Previously, it used Draft-04 or Draft-07, which permitted the earlier format.